### PR TITLE
Resolve 2 mismatch stubbings in ResultResolverNodeHierarchyTest.java

### DIFF
--- a/src/test/java/com/arangodb/graphql/query/result/resolver/ResultResolverNodeHierarchyTest.java
+++ b/src/test/java/com/arangodb/graphql/query/result/resolver/ResultResolverNodeHierarchyTest.java
@@ -161,6 +161,8 @@ public class ResultResolverNodeHierarchyTest {
         topLevelFieldValues.put("__collection", "Document");
         topLevelFieldValues.put("secondLevelField", 41);
 
+        when(topLevelFieldDefinition.getDirective("edgeTarget")).thenReturn(null);
+        when(resultVertices.get("Document/1")).thenReturn(null);
         //Have an Edge directive
         when(topLevelFieldDefinition.getDirective("edge")).thenReturn(edgeDirective);
         when(edgeDirective.getArgument("collection")).thenReturn(collectionArgument);


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

1. `getDirective` was executed with arguments "edgeTarget",  but was not stubbed, resulting in a mismatch stubbing, this mismatch occurs in the test `processWithTraversal`.

2. `get` was executed with arguments "Document/1" but was not stubbed, resulting in a mismatch stubbing, this mismatch occurs in the test `processWithTraversal`.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

We propose a solution below to resolve the mismatch stubbings.