### PR TITLE
Resolve 2 mismatch stubbings in ArangoEdgeDirectiveTest.java

### DIFF
--- a/src/test/java/com/arangodb/graphql/schema/ArangoEdgeDirectiveTest.java
+++ b/src/test/java/com/arangodb/graphql/schema/ArangoEdgeDirectiveTest.java
@@ -55,6 +55,7 @@ public class ArangoEdgeDirectiveTest {
         String expected = "collectionName";
 
         when(field.getDirective(eq("edge"))).thenReturn(schemaDirective);
+        when(schemaDirective.getArgument(eq("direction"))).thenReturn(null);
         when(schemaDirective.getArgument(eq("collection"))).thenReturn(argument);
         when(argument.getValue()).thenReturn(expected);
 
@@ -79,6 +80,7 @@ public class ArangoEdgeDirectiveTest {
     public void testNoCollection(){
 
         when(field.getDirective(eq("edge"))).thenReturn(schemaDirective);
+        when(schemaDirective.getArgument(eq("direction"))).thenReturn(null);
         when(schemaDirective.getArgument(eq("collection"))).thenReturn(null);
 
         directive = new ArangoEdgeDirective(field);


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

`getArgument` was executed with arguments "direction", but was not stubbed, resulting in a mismatched stubbing. This mismatch occurs in tests `testCollection` and `testNoCollection`.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

We propose a solution below to resolve the mismatch stubbings.